### PR TITLE
Add project scaffolding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install package
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+      - name: Run tests
+        run: python -m unittest discover -s tests

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,23 @@
-# gitignore template for LangChain products, e.g., LangGraph, LangSmith
-# website: https://www.langchain.com/
-# website: https://www.langchain.com/langgraph
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
 
-# LangGraph
-.langgraph_api/
+# Distribution / packaging
+.Python
+env/
+build/
+dist/
+*.egg-info/
+
+# Virtual environments
+venv/
+ENV/
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Local configuration
+.env
+*.local

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing
+
+Thank you for considering contributing to this project!
+
+## Getting started
+1. Fork the repository and create your branch from `main`.
+2. Install dependencies and run tests with `python -m unittest`.
+3. Submit a pull request describing your changes.
+
+## Code style
+- Keep the code simple and well documented.
+- Include tests for new functionality.
+
+## Security
+Do not commit secrets. Use environment variables or a `.env` file excluded from version control to manage credentials.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Umbra Versa
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
 # UV-agentic-project-repo-template
-Repo template for Umbra Versa agentic AI projects
+
+Template repository for Umbra Versa agentic AI projects.
+
+## Project structure
+
+```
+├── src/            # project code
+├── tests/          # unit tests
+├── docs/           # documentation
+└── .github/        # CI configuration
+```
+
+## Getting started
+1. Create a virtual environment and install the project in editable mode:
+   ```bash
+   python -m pip install -e .
+   ```
+2. Run tests:
+   ```bash
+   python -m unittest discover -s tests
+   ```
+
+## Security guidelines
+Secrets should never be committed to the repository. Use environment variables
+or a `.env` file excluded from version control for credentials.
+
+## License
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for
+more information.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+# Documentation
+
+This directory contains project documentation. Expand as the project grows.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "sample-agent"
+version = "0.1.0"
+description = "Sample agent package"
+readme = "README.md"
+requires-python = ">=3.8"

--- a/src/sample_agent/__init__.py
+++ b/src/sample_agent/__init__.py
@@ -1,0 +1,7 @@
+"""Sample agent library."""
+
+
+def greet(name: str) -> str:
+    """Return a greeting for the given name."""
+    return f"Hello, {name}!"
+

--- a/src/sample_agent/cli.py
+++ b/src/sample_agent/cli.py
@@ -1,0 +1,16 @@
+"""Command-line interface for the sample agent."""
+
+import argparse
+from . import greet
+
+
+def main() -> None:
+    """Run the CLI."""
+    parser = argparse.ArgumentParser(description="Sample agent CLI.")
+    parser.add_argument("name", help="Name to greet.")
+    args = parser.parse_args()
+    print(greet(args.name))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,11 @@
+import unittest
+from sample_agent import greet
+
+
+class TestGreet(unittest.TestCase):
+    def test_greet(self):
+        self.assertEqual(greet("World"), "Hello, World!")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- flesh out README with instructions and project layout
- add generic Python `.gitignore`
- provide sample package with CLI and tests
- document contribution guidelines and license
- configure GitHub Actions CI workflow

## Testing
- `python -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_684e5287249083278aabfcdf5744f875